### PR TITLE
fix: Use uiop:define-package instead

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -24,7 +24,7 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (in-package :cl-user)
-(defpackage :jingle
+(uiop:define-package :jingle
   (:use :cl)
   (:import-from :jingle.core)
   (:import-from :ningle)


### PR DESCRIPTION
The following warning occurs when reloading a package using `cl-reexport` (tested with SBCL 2.4.11).

```
CL-USER> (asdf:load-system :jingle)
WARNING: JINGLE also exports the following symbols:
  (JINGLE.CODES:LOOKUP-STATUS-CODE LACK/REQUEST:REQUEST-QUERY-STRING LACK/REQUEST:REQUEST-PARAMETERS JINGLE.CORE:CLEAR-MIDDLEWARES LACK/REQUEST:REQUEST-COOKIES LACK/REQUEST:REQUEST-SERVER-PORT LACK/REQUEST:REQUEST-CONTENT-LENGTH
                                   JINGLE.CORE:STATIC-PATH JINGLE.CORE:DEBUG-MODE JINGLE.UTILS:GET-RESPONSE-HEADER JINGLE.UTILS:WITH-JSON-RESPONSE NINGLE/CONTEXT:*CONTEXT* NINGLE/CONTEXT:MAKE-RESPONSE JINGLE.CORE:SERVE-DIRECTORY
                                   JINGLE.UTILS:SET-RESPONSE-BODY JINGLE.UTILS:SET-RESPONSE-STATUS JINGLE.CODES:STATUS-CODE-NUMBER NINGLE/CONTEXT:*REQUEST* JINGLE.CODES:EXPLAIN-STATUS-CODE NINGLE/APP:PROCESS-RESPONSE
                                   FIND-PORT:PORT-OPEN-P JINGLE.CORE:USE-THREAD NINGLE/APP:REQUIREMENT JINGLE.CODES:INFORMATIONAL-CODE-P LACK/REQUEST:REQUEST-REMOTE-PORT JINGLE.CORE:URL-FOR LACK/REQUEST:REQUEST-RAW-BODY
                                   JINGLE.UTILS:RESPONSE-HEADER-IS-SET-P JINGLE.CORE:HTTP-SERVER-KIND LACK/REQUEST:REQUEST-SERVER-NAME JINGLE.CORE:HTTP-SERVER JINGLE.CODES:*STATUS-CODES* JINGLE.CORE:BASE-HTTP-ERROR
                                   LACK/RESPONSE:RESPONSE-STATUS NINGLE/APP:NOT-FOUND JINGLE.CORE:REDIRECT-ROUTE JINGLE.CODES:STATUS-CODE-KIND JINGLE.CODES:SUCCESS-CODE-P FIND-PORT:FIND-PORT JINGLE.UTILS:WITH-HTML-RESPONSE
                                   JINGLE.CORE:HTTP-ERROR-CODE JINGLE.CODES:SERVER-ERROR-CODE-P JINGLE.CORE:HANDLE-ERROR JINGLE.CORE:MIDDLEWARES JINGLE.UTILS:GET-REQUEST-HEADER JINGLE.UTILS:REDIRECT LACK/REQUEST:REQUEST-METHOD
                                   LACK/REQUEST:REQUEST-ACCEPTS-P JINGLE.CORE:SILENT-MODE JINGLE.CORE:START LACK/REQUEST:REQUEST-CONTENT JINGLE.CORE:PORT NINGLE/APP:CLEAR-ROUTING-RULES LACK/REQUEST:REQUEST-ENV JINGLE.CORE:*ENV*
                                   NINGLE/CONTEXT:MAKE-REQUEST NINGLE/APP:ROUTE JINGLE.CODES:LOOKUP-STATUS-CODE-OR-LOSE LACK/RESPONSE:RESPONSE-HEADERS NINGLE/CONTEXT:*RESPONSE* JINGLE.CORE:HTTP-ERROR-BODY
                                   JINGLE.CODES:CLIENT-ERROR-CODE-P JINGLE.CORE:ADDRESS LACK/RESPONSE:RESPONSE-BODY LACK/REQUEST:REQUEST-REMOTE-ADDR LACK/REQUEST:REQUEST-PATH-INFO LACK/REQUEST:REQUEST-BODY-PARAMETERS
                                   JINGLE.UTILS:GET-REQUEST-PARAM NINGLE/CONTEXT:MAKE-CONTEXT JINGLE.CORE:FIND-ROUTE MYWAY.MAPPER:NEXT-ROUTE NINGLE/CONTEXT:CONTEXT JINGLE.CORE:MAKE-APP FIND-PORT:*DEFAULT-INTERFACE*
                                   JINGLE.UTILS:WITH-REQUEST-PARAMS NINGLE/CONTEXT:*SESSION* JINGLE.UTILS:REQUEST-HEADER-IS-SET-P LACK/REQUEST:REQUEST-QUERY-PARAMETERS NINGLE/CONTEXT:WITH-CONTEXT-VARIABLES JINGLE.CORE:APP
                                   JINGLE.CORE:INSTALL-MIDDLEWARE LACK/REQUEST:REQUEST-CONTENT-TYPE LACK/REQUEST:REQUEST-URI JINGLE.CORE:TEST-APP LACK/REQUEST:REQUEST-ACCEPT JINGLE.CORE:MAKE-TEST-APP LACK/REQUEST:REQUEST-HEADERS
                                   LACK/RESPONSE:RESPONSE-SET-COOKIES JINGLE.CORE:CONFIGURE JINGLE.CORE:STOP JINGLE.CODES:REDIRECTION-CODE-P LACK/REQUEST:REQUEST-URI-SCHEME LACK/REQUEST:REQUEST-SERVER-PROTOCOL
                                   LACK/REQUEST:REQUEST-SCRIPT-NAME LACK/REQUEST:REQUEST-HAS-BODY-P JINGLE.UTILS:SET-RESPONSE-HEADER)
See also:
  The ANSI Standard, Macro DEFPACKAGE
  The SBCL Manual, Variable *ON-PACKAGE-VARIANCE*
T
```

This issue can be resolved by using `uiop:define-package` instead of `defpackage`.